### PR TITLE
Prefer AGENT_HOMEDIRECTORY over HOME as bridge folder on linux systems

### DIFF
--- a/synopsys-task/src/synopsys-task/synopsys-bridge.ts
+++ b/synopsys-task/src/synopsys-task/synopsys-bridge.ts
@@ -498,7 +498,7 @@ export class SynopsysBridge {
       );
     } else if (osName === "linux") {
       bridgeDefaultPath = path.join(
-        process.env["HOME"] as string,
+        (process.env.hasOwnProperty("AGENT_HOMEDIRECTORY") ? process.env["AGENT_HOMEDIRECTORY"] : process.env["HOME"]) as string,
         constants.SYNOPSYS_BRIDGE_DEFAULT_PATH_LINUX
       );
     } else if (osName === "win32") {


### PR DESCRIPTION
Following this [documentation](https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#agent-variables-devops-services) it seems more reliable to use `Agent.HomeDirectory` for storing semi-persistent files, than using $HOME (which is not fully guaranteed to exist, although it should on any properly configured instance).

`Agent.TempDirectory` is specific to a build, and `Agent.WorkFolder` is not guaranteed to be writable.

Context: working on a linux agent without `HOME` variable - I'm aware this is off - resulting in task error `##[error]The "path" argument must be of type string. Received undefined`.

FWIW, could make the task a tiny bit more robust.