### PR TITLE
SIGINT-1937:  add project.source.preserveSymLinks for Polaris upload scan

### DIFF
--- a/synopsys-task/task.json
+++ b/synopsys-task/task.json
@@ -274,6 +274,16 @@
       "groupName": "scanOptions"
     },
     {
+      "name": "projectSourcePreserveSymLinks",
+      "type": "boolean",
+      "label": "Project Source Preserve SymLinks",
+      "defaultValue": false,
+      "required": false,
+      "helpMarkDown": "Flag indicating whether to preserve symlinks in the source zip",
+      "visibleRule": "polarisAssessmentMode = SOURCEUPLOAD",
+      "groupName": "scanOptions"
+    },
+    {
       "name": "bridge_coverity_connect_url",
       "type": "string",
       "label": "Coverity Platform URL",


### PR DESCRIPTION
- Added project.source.preserveSymLinks for Polaris upload scan